### PR TITLE
Only log when not dry run

### DIFF
--- a/gordian/gordian.py
+++ b/gordian/gordian.py
@@ -132,9 +132,9 @@ def apply_transformations(args, transformations):
             if not args.dry_run:
                 try:
                     repo.repo.create_pull(args.pr_message, '', 'master', repo.branch_name)
+                    logger.info(f'PR created: {args.pr_message}. Branch: {repo.branch_name}')
                 except GithubException as e:
-                    print(f'PR already exists for {repo.branch_name}')
-            logger.info(f'PR created: {args.pr_message}. Branch: {repo.branch_name}')
+                    logger.info(f'PR already exists for {repo.branch_name}')
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setup_reqs = ["pytest-cov", "pytest-runner", "flake8"]
 setuptools.setup(
     name="gordian",
-    version="0.2.0",
+    version="0.2.1",
     author="Intuit",
     author_email="cg-sre@intuit.com",
     description="A tool to search and replace YAML files in a Git repo",


### PR DESCRIPTION
'PR created' was being logged when `dry-run` was marked true, even though no PR was being created. Also switched `print` for `logger.info`.