### PR TITLE
Fix repo files issue

### DIFF
--- a/gordian/repo.py
+++ b/gordian/repo.py
@@ -12,7 +12,7 @@ BASE_URL = 'https://api.github.com'
 
 class Repo:
 
-    def __init__(self, repo_name, github_api_url=None, branch=None, git=None, files=[]):
+    def __init__(self, repo_name, github_api_url=None, branch=None, git=None, files=None):
         if github_api_url is None:
             self.github_api_url = BASE_URL
         else:
@@ -24,6 +24,9 @@ class Repo:
             else:
                 git = Github(base_url=self.github_api_url, login_or_token=os.environ['GIT_USERNAME'], password=os.environ['GIT_PASSWORD'])
 
+        if files is None:
+            files = []
+            
         self.repo_name = repo_name
         self._repo = git.get_repo(repo_name)
         self.files = files

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setup_reqs = ["pytest-cov", "pytest-runner", "flake8"]
 setuptools.setup(
     name="gordian",
-    version="1.1.2",
+    version="1.1.3",
     author="Intuit",
     author_email="cg-sre@intuit.com",
     description="A tool to search and replace YAML files in a Git repo",

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -43,3 +43,9 @@ class TestRepo(unittest.TestCase):
     def test_get_existing_object(self):
         contents = self.repo.get_objects('/content.yaml')
         assert(isinstance(contents, YamlFile))
+        
+    def test_new_files_object(self):
+        self.assertEquals(len(self.repo.files), 1)
+        repo_two = Repo('test_two', github_api_url='https://test.github.com', git=self.mock_git)
+        self.assertEquals(len(repo_two.files), 0)
+        


### PR DESCRIPTION
### Description
This PR fixes an issue with multiple instantiations of the Repo function utilizing the same file array.

- What Changed and Why? :
Changed the files default parameter to be None and then created an empty array when said parameter is None. This follows the guidelines outlined here: https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments .

- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

- Other:
  - [ ] Add unit tests
  - [ ] Add documentation
