### PR TITLE
Target branch for PRs, call back function after pr is created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ env/
 venv/
 
 config.yaml
+
+#vim
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com),
+and this project adheres to [Semantic Versioning](https://semver.org).
+
+## [1.3.0] - 2020-06-13
+### Added
+- This changelog
+- Support to call a function if the PR is created
+- Target branch support, now you can create PR against any branch, not only master
+### Changed
+- Refactored `apply_transformations` function to simplify passing the list of repositories from a different source
+

--- a/gordian/repo.py
+++ b/gordian/repo.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 BASE_URL = 'https://api.github.com'
 
 
-class Repo(object):
+class Repo:
 
     def __init__(self, repo_name, github_api_url=None, branch=None, git=None, files=None, semver_label=None, target_branch='master'):
         if github_api_url is None:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setup_reqs = ['pytest', 'pytest-cov', 'pytest-runner', 'flake8']
 setuptools.setup(
     name="gordian",
-    version="1.2.0",
+    version="1.3.0",
     author="Intuit",
     author_email="cg-sre@intuit.com",
     description="A tool to search and replace files in a Git repo",

--- a/tests/test_gordian.py
+++ b/tests/test_gordian.py
@@ -17,13 +17,17 @@ class TestGordian(unittest.TestCase):
             self.branch = 'test'
             self.github_api = None
             self.semver_label = None
+            self.target_branch = 'master'
 
     def test_apply_transformations_without_changes(self):
         with patch('gordian.gordian.Repo') as RepoMock, patch('gordian.transformations.Transformation') as TransformationMockClass:
             instance = RepoMock.return_value
             instance.dirty = False
             apply_transformations(TestGordian.Args(), [TransformationMockClass])
-            RepoMock.assert_has_calls([call('testOrg/TestService1', github_api_url=None, branch='test', semver_label=None), call('testOrg/TestService2', github_api_url=None, branch='test', semver_label=None)], any_order=True)
+            RepoMock.assert_has_calls([
+                call('testOrg/TestService1', github_api_url=None, branch='test', semver_label=None, target_branch='master'),
+                call('testOrg/TestService2', github_api_url=None, branch='test', semver_label=None, target_branch='master')
+                ])
 
     def test_apply_transformations_with_changes(self):
         with patch('gordian.gordian.Repo') as RepoMock, patch('gordian.transformations.Transformation', ) as TransformationMockClass:
@@ -40,3 +44,22 @@ class TestGordian(unittest.TestCase):
             apply_transformations(TestGordian.Args(dry_run=True), [TransformationMockClass])
             RepoMock.assert_has_calls([call().bump_version(True), call().bump_version(True)], any_order=True)
             self.assertNotIn(call().repo.create_pull('test', '', 'master', ANY), RepoMock.mock_calls)
+
+    def test_apply_transformations_with_changes_and_callback(self):
+        with patch('gordian.gordian.Repo') as RepoMock, patch('gordian.transformations.Transformation', ) as TransformationMockClass:
+            instance = RepoMock.return_value
+            instance.dirty = True
+            callback_mock = MagicMock()
+            args = TestGordian.Args()
+            args.target_branch = 'target_branch'
+            apply_transformations(args, [TransformationMockClass], callback_mock)
+            pull_request = RepoMock.return_value._repo.create_pull.return_value
+            RepoMock.assert_has_calls([call().bump_version(False), call().bump_version(False)], any_order=True)
+            RepoMock.assert_has_calls([
+                call()._repo.create_pull('test', '', 'target_branch', ANY),
+                call()._repo.create_pull('test', '', 'target_branch', ANY)],
+                any_order=True)
+            callback_mock.assert_has_calls([
+                call('testOrg/TestService1', pull_request),
+                call('testOrg/TestService2', pull_request)]
+                )


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

### What Changed and Why? :
- Added CHANGELOG.md 
- Added an option to target different branches, not only master.
- Refactored `apply_transformation` function to allow injecting the list of repositories from different sources, not only the configuration file.
- Exposed a new function `transform`
```python
from inventory import list_of_repositories
transform(args, transformations, list_of_repositories)
```
- Added support for a callback function once the pull request is created, for example:  
```python
def dummy_callback(repo_name, pull_request):
    issue = new_issue(repo_name)
    pull_request.edit(title=pull_request.title + f' - [{issue.id}]')
```

- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

- Other:
  - [x] Add unit tests
  - [ ] Add documentation
