### PR TITLE
Reseting the file cache when changing the target branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [1.4.1] - 2020-06-18
+### Fixed
+- set_target_branch was not cleaning the file cache, resulting in gordian not being able to get new files in the new branches.
+
 ## [1.4.0] - 2020-06-17
 ### Added
 - Print out PR URLs at the end of a Gordian run

--- a/gordian/repo.py
+++ b/gordian/repo.py
@@ -39,6 +39,7 @@ class Repo:
         self.branch_exists = False
         self.dirty = False
         self.semver_label = semver_label
+        self.target_branch = None
         self.set_target_branch(target_branch)
 
         logger.debug(f'Target ref: {target_branch}')
@@ -49,8 +50,13 @@ class Repo:
         logger.debug(f'Branch name for this changes: {self.branch_name}')
 
     def set_target_branch(self, branch):
+        if branch == self.target_branch:
+            return
+
         self.target_branch = branch
         self.target_ref = f"refs/heads/{self.target_branch}"
+        # Resetting the file cache when we change the branch
+        self.files = []
 
     def get_objects(self, filename, klass=None):
         file = self.find_file(filename)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setup_reqs = ['pytest', 'pytest-cov', 'pytest-runner', 'flake8']
 setuptools.setup(
     name="gordian",
-    version="1.4.0",
+    version="1.4.1",
     author="Intuit",
     author_email="cg-sre@intuit.com",
     description="A tool to search and replace files in a Git repo",

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -58,3 +58,14 @@ class TestRepo(unittest.TestCase):
         self.repo.get_files()
         self.repo._repo.get_contents.assert_has_calls([call('', 'refs/heads/target'), call('directory', 'refs/heads/target')])
         self.assertEquals(self.repo.files, [repository_file])
+
+    def test_set_target_branch(self):
+        cached_files = ['cached_file', 'cached_file', 'cached_file']
+        self.repo.files = cached_files.copy()
+        self.repo.set_target_branch('master')
+        self.assertEqual(self.repo.files, cached_files)
+
+        self.repo.set_target_branch('Something different')
+        self.assertEqual(self.repo.files, [])
+        self.assertEqual(self.repo.target_branch, 'Something different')
+        self.assertEqual(self.repo.target_ref, 'refs/heads/Something different')


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues: Gordian was not cleaning the files cache when the target branch was changed resulting in not being able to get files that were not present in the initial target branch.

- What Changed and Why? :

- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [x] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

- Other:
  - [x] Add unit tests
  - [ ] Add documentation
