### PR TITLE
Feat/start using docker entrypoint script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [2.1.2] - 2020-06-25
+### Added
+ - Added entrypoint script to meet requirements of official docker image consistency
+
 ## [2.1.1] - 2020-06-23
 ### Fixed
 - Fixed setting the labels twice when releasing 2.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ USER root
 RUN apt-get update && apt-get install -y --no-install-recommends python3 python-pip python-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /rep /rep
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 WORKDIR /rep
 RUN pip3 install --no-index --find-links=/rep/wheels .
-ENTRYPOINT ["gordian"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["gordian"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# this if will check if the first argument is a flag
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- gordian "$@"
+fi
+
+# check for the expected command
+if [ "$1" = 'gordian' ]; then
+    exec gordian "$@"
+fi
+
+# else default to run whatever the user wanted like "bash" or "sh"
+exec "$@"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setup_reqs = ['pytest', 'pytest-cov', 'pytest-runner', 'flake8']
 setuptools.setup(
     name="gordian",
-    version="2.1.1",
+    version="2.1.2",
     author="Intuit",
     author_email="cg-sre@intuit.com",
     description="A tool to search and replace files in a Git repo",


### PR DESCRIPTION
### Description
- Relevant Issues :

When I tried to use this image in one of our Jenkins pipelines it failed because our pipeline (for whatever reason) tries to issue a command for a container before running it to check if the images were built according to the requirements by the official docker images. Well, this failed, hence this PR.

- What Changed and Why? :

ENTRYPOINT should execute the command passed as docker run argument as required by official docker images (see https://github.com/docker-library/official-images#consistency for entrypoint consistency requirements).

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [X] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

- Other:
  - [ ] Add unit tests
  - [ ] Add documentation

Also wanted to add a thank you, for all the work that has gone into this very cool tool.