### PR TITLE
Removing .git from repo_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [3.1.1] - 2020-12-11
+### Fix
+- Remove '.git' from repo_name
+
 ## [3.1.0] - 2020-08-26
 ### Added
 - Allow `repo#create_pr` to be called without setting labels

--- a/gordian/repo.py
+++ b/gordian/repo.py
@@ -35,6 +35,9 @@ class Repo:
             files = []
         self.files = files
 
+        if repo_name.endswith('.git'):
+            repo_name = repo_name[:-4]
+
         self._initialize_repos(repo_name, fork)
 
         self.version_file = None

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setup_reqs = ['pytest', 'pytest-cov', 'pytest-runner', 'flake8']
 setuptools.setup(
     name="gordian",
-    version="3.1.0",
+    version="3.1.1",
     author="Intuit",
     author_email="cg-sre@intuit.com",
     description="A tool to search and replace files in a Git repo",

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -18,18 +18,24 @@ class TestRepo(unittest.TestCase):
         self.mock_repo.get_branches.return_value = self.mock_branches
         self.mock_git.get_repo.return_value = self.mock_repo
 
+    @patch('gordian.repo.Github')
+    def test_remove_dot_git_from_repo_name(self, mock_git):
+        self.mock_git.reset_mock()
+        self.repo = Repo('test.git', github=self.mock_git)
+        self.mock_git.get_repo.assert_called_once_with('test')
+
     def test_no_fork(self):
-        repo = Repo(None, branch='', github=self.mock_git, fork=False)
+        repo = Repo('test_repo', branch='', github=self.mock_git, fork=False)
         repo._target_repo.create_fork.assert_not_called()
         self.assertEqual(repo._source_repo, repo._target_repo)
 
     def test_fork(self):
-        repo = Repo(None, branch='', github=self.mock_git, fork=True)
+        repo = Repo('test_repo', branch='', github=self.mock_git, fork=True)
         repo._target_repo.create_fork.assert_called_once()
         self.assertNotEqual(repo._source_repo, repo._target_repo)
 
     def test_make_branch_fork(self):
-        repo = Repo(None, branch='', github=self.mock_git, fork=True)
+        repo = Repo('test_repo', branch='', github=self.mock_git, fork=True)
         repo.branch_exists = False
         mock_branch = MagicMock()
         self.mock_repo.get_branch.return_value = mock_branch
@@ -40,7 +46,7 @@ class TestRepo(unittest.TestCase):
         repo._source_repo.create_git_ref.assert_called_once()
 
     def test_make_branch_no_fork(self):
-        repo = Repo(None, branch='', github=self.mock_git, fork=False)
+        repo = Repo('test_repo', branch='', github=self.mock_git, fork=False)
         repo.branch_exists = False
         mock_branch = MagicMock()
         self.mock_repo.get_branch.return_value = mock_branch
@@ -100,7 +106,7 @@ class TestRepo(unittest.TestCase):
         self.assertEqual(self.repo.target_ref, 'refs/heads/Something different')
 
     def test_create_pr(self):
-        repo = Repo(None, branch='', github=self.mock_git)
+        repo = Repo('test_repo', branch='', github=self.mock_git)
         repo._target_repo = MagicMock()
         repo._source_repo = MagicMock()
         repo._source_repo.owner.login = 'someone'
@@ -111,7 +117,7 @@ class TestRepo(unittest.TestCase):
         repo._source_repo.create_pull.assert_not_called()
 
     def test_create_pr_no_labels(self):
-        repo = Repo(None, branch='', github=self.mock_git)
+        repo = Repo('test_repo', branch='', github=self.mock_git)
         repo._target_repo = MagicMock()
         repo._source_repo = MagicMock()
         repo._source_repo.owner.login = 'someone'

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -19,7 +19,7 @@ class TestSearchAndReplaceTransformation(unittest.TestCase):
         self.mock_repo.get_branches.return_value = self.mock_branches
         mock_git.get_repo.return_value = self.mock_repo
         self.mock_repo.get_contents.return_value = []
-        self.instance = Repo(None, branch='', github=mock_git, files=[])
+        self.instance = Repo('test_repo', branch='', github=mock_git, files=[])
         self.instance.branch_exists = False
         f = open('./tests/fixtures/content.yaml', 'r')
         contents = f.read()


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : Github api returns 404 if the repository name contains .git. Making sure it doesn't happen.

- What Changed and Why? :

- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

- Other:
  - [x] Add unit tests
  - [ ] Add documentation
