### PR TITLE
Repo object can now return github attribute

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/gordian/repo.py
+++ b/gordian/repo.py
@@ -246,3 +246,6 @@ class Repo:
         elif self.semver_label == 'patch':
             patch = str(int(patch) + 1)
         self.new_version = '.'.join([major, minor, patch])
+    
+    def get_github_client(self):
+        return self._github

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 setup_reqs = ["pytest", "pytest-cov", "pytest-runner", "flake8"]
 setuptools.setup(
     name="gordian",
-    version="3.3.0",
+    version="3.4.0",
     author="Intuit",
     author_email="cg-sre@intuit.com",
     description="A tool to search and replace files in a Git repo",

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -152,4 +152,4 @@ class TestRepo(unittest.TestCase):
         self.assertEqual(self.repo.new_version, '1.2.4')
 
     def test__get_github_client(self):
-        self.assertIsNotNone(self._github)
+        self.assertIsNotNone(self.repo.get_github_client)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -150,3 +150,6 @@ class TestRepo(unittest.TestCase):
         self.repo.semver_label = 'patch'
         self.repo._get_new_version()
         self.assertEqual(self.repo.new_version, '1.2.4')
+
+    def test__get_github_client(self):
+        self.assertIsNotNone(self._github)


### PR DESCRIPTION
The repository object had a private attribute for github. Added a method to return it which can be used for many things such as fetching branches and pull requests of a repository.

### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues :

- What Changed and Why? :

- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

- Other:
  - [x] Add unit tests
  - [ ] Add documentation
