### PR TITLE
Allow path define on get files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [3.6.0] - 2023-05-16
+### Added
+- Added support to pass in a path when calling get_files(), resolves issue #34
+
 ## [3.5.0] - 2023-05-16
 ### Added
 - Added support to pass in a github token, username and password as named parameters

--- a/gordian/repo.py
+++ b/gordian/repo.py
@@ -77,9 +77,9 @@ class Repo:
 
         return PlainTextFile(file, self)
 
-    def get_files(self):
+    def get_files(self, path=''):
         if not self.files:
-            contents = self._get_repo_contents('')
+            contents = self._get_repo_contents(path)
 
             while contents:
                 file = contents.pop(0)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 setup_reqs = ["pytest", "pytest-cov", "pytest-runner", "flake8"]
 setuptools.setup(
     name="gordian",
-    version="3.5.0",
+    version="3.6.0",
     author="Intuit",
     author_email="cg-sre@intuit.com",
     description="A tool to search and replace files in a Git repo",

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -191,6 +191,16 @@ class TestRepo(unittest.TestCase):
         repo._source_repo.delete_file.assert_called_once()
         self.assertTrue(repo.dirty)
 
+    def test_get_files_with_path(self):
+        self.repo._set_target_branch('target')
+        self.repo.files = []
+        self.repo._source_repo = MagicMock()
+        repository_file = MagicMock(path='test/afile.txt', type='not_dir')
+        self.repo._source_repo.get_contents.side_effect = [[MagicMock(path='directory', type='dir')],[repository_file]]
+        self.repo.get_files('test')
+        self.repo._source_repo.get_contents.assert_has_calls([call('test', 'refs/heads/target'), call('directory', 'refs/heads/target')])
+        self.assertEquals(self.repo.files, [repository_file])
+
     def test__get_github_client(self):
         repo = Repo('test_repo', branch='', github=self.mock_git)
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -198,7 +198,7 @@ class TestRepo(unittest.TestCase):
         repository_file = MagicMock(path='test/afile.txt', type='not_dir')
         self.repo._source_repo.get_contents.side_effect = [[MagicMock(path='directory', type='dir')],[repository_file]]
         self.repo.get_files('test')
-        self.repo._source_repo.get_contents.assert_has_calls([call('test', 'refs/heads/target'), call('directory', 'refs/heads/target')])
+        self.repo._source_repo.get_contents.assert_has_calls([call('test', 'target'), call('directory', 'target')])
         self.assertEquals(self.repo.files, [repository_file])
 
     def test__get_github_client(self):


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues :

- What Changed and Why? :
- Adds the ability to set a path when calling `get_files()` to support sparse checkouts, should resolve #34 

- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

- Other:
  - [X] Add unit tests
  - [ ] Add documentation
